### PR TITLE
解决编译警告和内存泄漏问题

### DIFF
--- a/lua_rax.c
+++ b/lua_rax.c
@@ -38,7 +38,8 @@ lrax_insert(lua_State *L) {
     }
 
     int idx = luaL_checkinteger(L, 3);
-    int ret = raxInsert(r, buf, len, (void *)idx, NULL);
+	void* data = &idx;
+    int ret = raxInsert(r, buf, len, data, NULL);
     lua_pushboolean(L, ret);
     return 1;
 }
@@ -60,7 +61,7 @@ lrax_find(lua_State *L) {
     if (res == raxNotFound) {
         return 0;
     }
-    int idx = (int)res;
+    int idx = *((int*)res);
     lua_pushinteger(L, idx);
     return 1;
 }
@@ -113,7 +114,7 @@ lrax_prev(lua_State *L) {
         break;
     }
 
-    int idx = (int)iter->data;
+    int idx = *((int*)iter->data);
     lua_pushinteger(L, idx);
     return 1;
 }
@@ -142,7 +143,7 @@ lrax_next(lua_State *L) {
         return 1;
     }
 
-    int idx = (int)iter->data;
+    int idx = *((int*)iter->data);
     lua_pushinteger(L, idx);
     return 1;
 }

--- a/rax.lua
+++ b/rax.lua
@@ -2,6 +2,7 @@ local rax_core = require "rax.core"
 
 local function gc_free(self)
     rax_core.destroy(self.tree)
+	rax_core.stop(self.tree_it)
 end
 
 local M = { VERSION = '0.0.1' }


### PR DESCRIPTION
![{FFE5201A-54AE-4EB4-82E1-9897E7F59A5F}](https://github.com/hanxi/lua-rax/assets/41766775/31406a8a-915a-4d1e-afeb-5f984a76c681)
![{06FB2DC8-CEE9-4B91-B3DB-A10BB67D3074}](https://github.com/hanxi/lua-rax/assets/41766775/a33a4a32-8a01-4a81-b373-26b368a9c13a)

https://github.com/antirez/rax
rax的readme中有说到。

迭代器可以多次使用，并且可以多次查找而raxSeek无需raxStart再次调用。但是，当不再使用迭代器时，必须通过以下调用回收其内存：

raxStop(&iter);
请注意，即使您不调用raxStop，大多数时候您也不会检测到任何内存泄漏，但这只是 Rax 实现工作方式的副作用：大多数时候它会尝试使用堆栈分配的数据结构。然而对于深树或大键，将分配堆内存，调用失败raxStop将导致内存泄漏。